### PR TITLE
Add #load_object to make inherited class behaviour more consistent 

### DIFF
--- a/lib/cache/base.rb
+++ b/lib/cache/base.rb
@@ -69,7 +69,7 @@ module Cache
     private
 
     def load_objects(keys)
-      keys.inject(Hash.new) do |objects_hash, key|
+      keys.each_with_object(Hash.new) do |objects_hash, key|
         objects_hash[key] = load_object(key)
       end
     end

--- a/lib/cache/base.rb
+++ b/lib/cache/base.rb
@@ -18,7 +18,6 @@ module Cache
       def instance
         @instance ||= new
       end
-
     end
 
     def fetch(key)
@@ -26,7 +25,7 @@ module Cache
       trobj = cache_store.read(trkey, cache_store_call_options)
 
       unless trobj # No object in cache, load new one
-        trobj = transform_cache_object(load_objects([key])[key])
+        trobj = transform_cache_object(load_object(key))
         cache_store.write(trkey, trobj, cache_store_call_options)
       end
 
@@ -60,7 +59,7 @@ module Cache
     end
 
     def update(key, object = nil)
-      cache_store.write(transform_cache_key(key), transform_cache_object(object || load_objects([key])[key]), cache_store_call_options)
+      cache_store.write(transform_cache_key(key), transform_cache_object(object || load_object(key)), cache_store_call_options)
     end
 
     def invalidate(key)
@@ -70,6 +69,12 @@ module Cache
     private
 
     def load_objects(keys)
+      keys.inject(Hash.new) do |objects_hash, key|
+        objects_hash[key] = load_object(key)
+      end
+    end
+
+    def load_object(key)
       raise StandardError, "Object loading not implemented"
     end
 

--- a/lib/cache/exts/active_record_loading.rb
+++ b/lib/cache/exts/active_record_loading.rb
@@ -14,6 +14,10 @@ module Cache
         Hash[scope.find(keys).map{ |r| [r.id, r] }]
       end
 
+      def load_object(key)
+        scope.find(key)
+      end
+
     end
   end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -67,7 +67,7 @@ describe TestBaseCache do
       key = double
       object = double
 
-      expect(subject).to receive(:load_objects).with([key]).and_return(key => object)
+      expect(subject).to receive(:load_object).with(key).and_return(object)
       expect(subject.cache_store).to receive(:write).with([:test_cache, key], object, subject.cache_store_call_options)
 
       subject.update(key)
@@ -94,7 +94,7 @@ describe TestBaseCache do
       transformed = double("transformed object")
 
       expect(subject.cache_store).to receive(:read).with([:test_cache, key], subject.cache_store_call_options).and_return(nil)
-      expect(subject).to receive(:load_objects).with([key]).and_return(key => object)
+      expect(subject).to receive(:load_object).with(key).and_return(object)
       expect(subject.cache_store).to receive(:write).with([:test_cache, key], object, subject.cache_store_call_options)
       expect(subject).to receive(:transform_value_object).with(object).and_return(transformed)
 

--- a/spec/exts/decorate_object_spec.rb
+++ b/spec/exts/decorate_object_spec.rb
@@ -33,7 +33,7 @@ describe TestDecorateObjectCache do
       decorated = double("decorated object")
 
       expect(object).to receive(:decorate).and_return(decorated)
-      expect(subject).to receive(:load_objects).with([key]).and_return(key => object)
+      expect(subject).to receive(:load_object).with(key).and_return(object)
       expect(subject.cache_store).to receive(:write).with(key, decorated, subject.cache_store_call_options)
 
       subject.update(key)

--- a/spec/exts/fields_spec.rb
+++ b/spec/exts/fields_spec.rb
@@ -23,7 +23,7 @@ describe TestFieldsCache do
       object = double("object", field1: 'aaa', field2: 123)
 
       expect(subject.cache_store).to receive(:read).and_return(nil)
-      expect(subject).to receive(:load_objects).with([key]).and_return(key => object)
+      expect(subject).to receive(:load_object).with(key).and_return(object)
       expect(subject.cache_store).to receive(:write)
 
       expect(subject.fetch(key)).to eq ::Hashie::Mash.new(field1: 'aaa', field2: 123, blank?: false, present?: true)

--- a/spec/exts/stacking_exts_spec.rb
+++ b/spec/exts/stacking_exts_spec.rb
@@ -27,7 +27,7 @@ describe TestStrackingCache do
       expect(object).to receive(:decorate).and_return(decorated)
 
       expect(subject.cache_store).to receive(:read).and_return(nil)
-      expect(subject).to receive(:load_objects).with([key]).and_return(key => object)
+      expect(subject).to receive(:load_object).with(key).and_return(object)
       expect(subject.cache_store).to receive(:write)
 
       expect(subject.fetch(key)).to eq ::Hashie::Mash.new(field1: 'aaa', field2: 123, blank?: false, present?: true)


### PR DESCRIPTION
Add #load_object 
Make #load_objects construct a `Hash`
