### PR TITLE
Travis complains about invalid gemspec

### DIFF
--- a/cache.gemspec
+++ b/cache.gemspec
@@ -6,8 +6,7 @@ Gem::Specification.new do |s|
   s.version       = Cache::VERSION
   s.authors       = ["Alexey Noskov"]
   s.email         = ["alexey.noskov@gmail.com"]
-  s.summary       = %q{TODO: Write a short summary. Required.}
-  s.description   = %q{TODO: Write a longer description. Optional.}
+  s.summary       = %q{Interface for rails local caching}
   s.homepage      = ""
   s.license       = "MIT"
 


### PR DESCRIPTION
Just removed description.

```
The gemspec at /home/travis/build/OnlinetoursGit/onlinetours/vendor/bundle/ruby/2.2.0/bundler/gems/cache-6712c0f68526/cache.gemspec is not valid. The validation error was '"FIXME" or "TODO" is not a description'
```
