### PR TITLE
Fix key conflict warning by converting them into methods

### DIFF
--- a/lib/cache/exts/fields.rb
+++ b/lib/cache/exts/fields.rb
@@ -28,9 +28,15 @@ module Cache
       end
 
       def transform_value_object(*)
-        ::Hashie::Mash.new(super.merge(blank?: false, present?: true)) { |_, key| raise NoMethodError, "undefined method '#{key}' for cached data" }
+        ::Hashie::Mash.new(super) do |_, key|
+          raise NoMethodError, "undefined method '#{key}' for cached data"
+        end.tap do |h|
+          class << h
+            def blank?; false; end unless respond_to? :blank?
+            def present?; true; end unless respond_to? :present?
+          end
+        end
       end
-
     end
   end
 end

--- a/spec/exts/fields_spec.rb
+++ b/spec/exts/fields_spec.rb
@@ -17,18 +17,42 @@ end
 describe TestFieldsCache do
 
   describe "#fetch" do
+    let(:key) { double("key") }
+    let(:object) { double("object", field1: 'aaa', field2: 123) }
 
-    it 'should load missed object as mash with given fields' do
-      key = double("key")
-      object = double("object", field1: 'aaa', field2: 123)
+    context 'present? and blank? methods are not defined in Hash' do
+      it 'should load missed object as mash with given fields' do
+        expect(subject.cache_store).to receive(:read).and_return(nil)
+        expect(subject).to receive(:load_object).with(key).and_return(object)
+        expect(subject.cache_store).to receive(:write)
 
-      expect(subject.cache_store).to receive(:read).and_return(nil)
-      expect(subject).to receive(:load_object).with(key).and_return(object)
-      expect(subject.cache_store).to receive(:write)
-
-      expect(subject.fetch(key)).to eq ::Hashie::Mash.new(field1: 'aaa', field2: 123, blank?: false, present?: true)
+        value = subject.fetch(key)
+        expect(value.field1).to eq 'aaa'
+        expect(value.field2).to eq 123
+        expect(value.blank?).to eq false
+        expect(value.present?).to eq true
+      end
     end
 
+    context 'present? and blank? methods already exist in Hash' do
+      before do
+        Hash.define_method(:blank?) { false }
+        Hash.define_method(:present?) { true }
+      end
+
+      it 'should not add blank? and present? keys unless missed' do
+        expect(subject.cache_store).to receive(:read).and_return(nil)
+        expect(subject).to receive(:load_object).with(key).and_return(object)
+        expect(subject.cache_store).to receive(:write)
+
+
+        value = subject.fetch(key)
+        expect(value.field1).to eq 'aaa'
+        expect(value.field2).to eq 123
+        expect(value.blank?).to eq false
+        expect(value.present?).to eq true
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Fix warnings like these:
```
W, [2019-06-06T22:30:56.105350 #14156]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#blank? defined in Hashie::Mash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
W, [2019-06-06T22:30:56.105473 #14156]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#present? defined in Hashie::Mash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
```
caused by merging `blank?` and `present?` keys to a list.